### PR TITLE
Add basic signup persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ php -S localhost:8000
 ```
 
 Visit `http://localhost:8000/login.php` to initiate the login flow.
+
+When a user logs in for the first time, their Google account information is
+stored in `users.txt`. Subsequent logins will read the stored data so it can be
+accessed later.


### PR DESCRIPTION
## Summary
- add persistent `users.txt`
- persist user info on OAuth callback and reuse on login
- document signup behaviour

## Testing
- `php -l login.php callback.php config.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515c9f0dac8329a3f73a2e2749fe55